### PR TITLE
feat: [DMND-127] only fire cv when zcId exists

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://zeroclick.ai"
 documentation: "https://zeroclick.ai/documentation-conversion-tag"
 versions:
+  - sha: f72a386e10370366845d1bcfcd648f7e7beefa03
+    changeNotes: Only fire conversion tracking when zcId is present
   - sha: 45f2dc633d7474678a36c885101ea4f963c6b107
     changeNotes: Update valueHint and add defaultValue field
   - sha: c0d35fd24b7f7ad23c679c2fc79c30690998b57f

--- a/template.tpl
+++ b/template.tpl
@@ -99,14 +99,17 @@ function getStoredId() {
 
 const zcId = getStoredId();
 
+// Only fire conversion if zcId is present
+if (!zcId) {
+  log('ZeroClick: No zcId found, skipping conversion tracking');
+  data.gtmOnSuccess();
+  return;
+}
 
 // Build tracking URL with pixel ID
 let trackingUrl = 'https://mcp.zeroclick.ai/api/v1/offers/cv';
 trackingUrl = trackingUrl + '?pixelId=' + encodeUriComponent(pixelId);
-
-if (zcId) {
-  trackingUrl = trackingUrl + '&zcId=' + encodeUriComponent(zcId);
-}
+trackingUrl = trackingUrl + '&zcId=' + encodeUriComponent(zcId);
 
 // Add optional conversion value
 if (data.conversionValue) {


### PR DESCRIPTION
https://linear.app/zeroclick2/issue/DMND-127/global-tracking-pixel-or-block-conversion-pixel-firing-when-no-zcid